### PR TITLE
Update field constructor to match convention of other fm fields

### DIFF
--- a/php/class-fieldmanager-gallery.php
+++ b/php/class-fieldmanager-gallery.php
@@ -83,7 +83,13 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 	 * @param string $label
 	 * @param array  $options
 	 */
-	public function __construct( $label, $options = array() ) {
+	public function __construct( $label = '', $options = array() ) {
+
+		if ( is_array( $label ) ) {
+			$options = $label;
+		} else {
+			$options['label'] = $label;
+		}
 
 		$this->plugin_dir = FM_GALLERY_PATH;
 		$this->plugin_url = FM_GALLERY_URL;


### PR DESCRIPTION
Other Fieldmanager_Fields allow for this convention, where the first parameter is the array of options.  This is the same logic that's used in the Fieldmanager_Field constructor. 