### PR TITLE
Add support for removing a gallery

### DIFF
--- a/js/fieldmanager-gallery.js
+++ b/js/fieldmanager-gallery.js
@@ -180,6 +180,9 @@ var fm_gallery_frame = [];
 			// Store value for saving
 			$el.parent().find( '.fm-gallery-id' ).val( ids.join( ',' ) );
 
+			// Enable the "Empty Gallery" button.
+			$el.parent().find( '.fm-gallery-button-empty' ).prop( 'disabled', false );
+
 			// Append gallery items
 			var $wrapper = $el.parent().find( '.gallery-wrapper' );
 			$wrapper
@@ -203,5 +206,23 @@ var fm_gallery_frame = [];
 
 		// Remove Gallery Settings
 		$( fm_gallery_frame[ $el.attr( 'id' ) ].$el ).find( '.gallery-settings' ).parent().remove();
+	} );
+
+	/**
+	 * Clicking on the "Empty Gallery" button
+	 */
+	$document.on( 'click', '.fm-gallery-button-empty', function( event ) {
+		var $el = $( this );
+
+		event.preventDefault();
+		$el.prop( 'disabled', true );
+
+		$el.parent().find( '.fm-gallery-id' ).val( '' );
+
+		var galleryId = $el.parent().find( '.fm-gallery-button' ).attr( 'id' );
+		delete fm_gallery_frame[ galleryId ];
+
+		var $wrapper = $el.parent().find( '.gallery-wrapper' );
+		$wrapper.html( '' );
 	} );
 } )( jQuery );

--- a/php/class-fieldmanager-gallery.php
+++ b/php/class-fieldmanager-gallery.php
@@ -20,6 +20,13 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 	public $button_label;
 
 	/**
+	 * Empty button label
+	 *
+	 * @var string
+	 */
+	public $empty_button_label;
+
+	/**
 	 * Button label in the gallery modal popup
 	 *
 	 * @var string
@@ -96,6 +103,7 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 
 		if ( ! empty( $options['collection'] ) ) {
 			$this->button_label       = __( 'Attach Gallery', 'fieldmanager' );
+			$this->empty_button_label = __( 'Empty Gallery', 'fieldmanager' );
 			$this->modal_button_label = __( 'Select Attachments', 'fieldmanager' );
 			$this->modal_title        = __( 'Choose Attachments', 'fieldmanager' );
 		} else {
@@ -115,8 +123,8 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 
 		if ( ! self::$has_registered_gallery ) {
 			add_action( 'admin_enqueue_scripts', function() {
-				wp_enqueue_style( 'fm_gallery', $this->plugin_url . 'css/fieldmanager-gallery.css', array() );
-				wp_enqueue_script( 'fm_gallery', $this->plugin_url . 'js/fieldmanager-gallery.js', array( 'jquery' ) );
+				wp_enqueue_style( 'fm_gallery', $this->plugin_url . 'css/fieldmanager-gallery.css', array(), FM_GALLERY_VERSION );
+				wp_enqueue_script( 'fm_gallery', $this->plugin_url . 'js/fieldmanager-gallery.js', array( 'jquery' ), FM_GALLERY_VERSION );
 				wp_localize_script( 'fm_gallery', 'fm_gallery', array(
 					'uploaded_file'  => __( 'Uploaded file', 'fieldmanager' ),
 					'remove'         => __( 'remove', 'fieldmanager' ),
@@ -201,8 +209,9 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 		$input_value = implode( ',', $values );
 
 		return sprintf(
-			'<input type="button" class="fm-gallery-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-collection="%9$s" />
-			<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-gallery-id" />
+			'<input type="button" class="fm-gallery-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-collection="%9$s" />' .
+			( $this->collection ? ' <input type="button" class="fm-gallery-button-empty button-secondary" value="%10$s"' . disabled( empty( $input_value ), true, false ) . ' />' : '' ) .
+			'<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-gallery-id" />
 			<div class="gallery-wrapper">%5$s</div>
 			<script type="text/javascript">
 			var fm_preview_size = fm_preview_size || [];
@@ -216,7 +225,8 @@ class Fieldmanager_Gallery extends Fieldmanager_Field {
 			wp_json_encode( $this->preview_size ),
 			esc_attr( $this->modal_title ),
 			esc_attr( $this->modal_button_label ),
-			intval( $this->collection )
+			intval( $this->collection ),
+			esc_attr( $this->empty_button_label )
 		);
 	}
 }


### PR DESCRIPTION
Currently, once a gallery is saved, it's impossible to entirely remove it. Images in a gallery can be reordered and removed, but if the final image is removed, the gallery cannot be saved in an empty state.